### PR TITLE
Use env vars for GsDevKit_* branch and remote names 

### DIFF
--- a/bin/updateGsDevKit
+++ b/bin/updateGsDevKit
@@ -32,10 +32,10 @@ source ${GS_HOME}/bin/defGsDevKit.env
 
 source ${GS_HOME}/bin/private/gitFunctions
 
-updateClone $GS_DEV_GIT_CHECKOUT "$GS_CLIENT_DEV"
+updateClone $GSDEVKIT_DEV_GIT_CHECKOUT "$GS_CLIENT_DEV"
 
 if [ -d "$GS_CLIENT_DEV/todeClient" ]; then
-  updateClone $GS_TODE_CLIENT_GIT_CHECKOUT "$GS_CLIENT_DEV/todeClient"
+  updateClone $GSDEVKIT_TODE_CLIENT_GIT_CHECKOUT "$GS_CLIENT_DEV/todeClient"
 fi
 
 pushd $GS_CLIENT_DEV_CLIENTS >& /dev/null

--- a/bin/updateGsDevKit
+++ b/bin/updateGsDevKit
@@ -35,7 +35,7 @@ source ${GS_HOME}/bin/private/gitFunctions
 updateClone $GSDEVKIT_DEV_GIT_CHECKOUT "$GS_CLIENT_DEV"
 
 if [ -d "$GS_CLIENT_DEV/todeClient" ]; then
-  updateClone $GSDEVKIT_TODE_CLIENT_GIT_CHECKOUT "$GS_CLIENT_DEV/todeClient"
+  updateClone $GSDEVKIT_TODE_CLIENT_GIT_CHECKOUT $GSDEVKIT_TODE_CLIENT_GIT_REMOTE "$GS_CLIENT_DEV/todeClient"
 fi
 
 pushd $GS_CLIENT_DEV_CLIENTS >& /dev/null

--- a/bin/updateGsDevKit
+++ b/bin/updateGsDevKit
@@ -32,7 +32,7 @@ source ${GS_HOME}/bin/defGsDevKit.env
 
 source ${GS_HOME}/bin/private/gitFunctions
 
-updateClone $GSDEVKIT_DEV_GIT_CHECKOUT "$GS_CLIENT_DEV"
+updateClone $GSDEVKIT_DEV_GIT_CHECKOUT $GSDEVKIT_DEV_GIT_REMOTE "$GS_CLIENT_DEV"
 
 if [ -d "$GS_CLIENT_DEV/todeClient" ]; then
   updateClone $GSDEVKIT_TODE_CLIENT_GIT_CHECKOUT $GSDEVKIT_TODE_CLIENT_GIT_REMOTE "$GS_CLIENT_DEV/todeClient"

--- a/bin/updateGsDevKit
+++ b/bin/updateGsDevKit
@@ -32,10 +32,10 @@ source ${GS_HOME}/bin/defGsDevKit.env
 
 source ${GS_HOME}/bin/private/gitFunctions
 
-updateClone master "$GS_CLIENT_DEV"
+updateClone $GS_DEV_GIT_CHECKOUT "$GS_CLIENT_DEV"
 
 if [ -d "$GS_CLIENT_DEV/todeClient" ]; then
-  updateClone master "$GS_CLIENT_DEV/todeClient"
+  updateClone $GS_TODE_CLIENT_GIT_CHECKOUT "$GS_CLIENT_DEV/todeClient"
 fi
 
 pushd $GS_CLIENT_DEV_CLIENTS >& /dev/null


### PR DESCRIPTION
With env vars, it means that one can choose to use a different branch than `master` as your **working branch**  so the upgradeGsDevKit script knows which remote and branch to update from ....

Coordinate with https://github.com/GsDevKit/GsDevKit_home/pull/2
